### PR TITLE
[KEYCL-130] Upgrade to Keycloak 16.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Add a password hash provider to handle BCrypt passwords inside Keycloak.
 ```bash
 cp build/libs/keycloak-bcrypt-1.5.0.jar docker/
 docker-compose up -d
+# Waiting for Keycloak startup
+docker-compose exec keycloak /opt/jboss/keycloak/bin/add-user-keycloak.sh -u admin -p admin # to create admin user
+docker-compose restart keycloak
 ```
 
 ## Install

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.github.leroyguillaume"
-version = "1.5.0"
+version = "16.1.0"
 
 publishing {
     publications {
@@ -30,7 +30,7 @@ repositories {
 dependencies {
     val bcryptVersion = "0.9.0"
     val jbossLoggingVersion = "3.4.1.Final"
-    val keycloakVersion = "14.0.0"
+    val keycloakVersion = "16.1.0"
 
     // BCrypt
     implementation("at.favre.lib:bcrypt:$bcryptVersion")
@@ -46,6 +46,11 @@ dependencies {
 }
 
 tasks {
+    java {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
     jar {
         from(configurations.runtimeClasspath.get().map { if (it.isDirectory) it else zipTree(it) }) {
             exclude("META-INF/MANIFEST.MF")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 }
 
 group = "com.github.leroyguillaume"
+// pin the nexus artifact version at the Keycloak server version
 version = "16.1.0"
 
 publishing {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,4 +20,4 @@ services:
     ports:
       - 8080:8080
     security_opt:
-      label: disable
+      - 'label:disable'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,3 @@
-FROM jboss/keycloak:10.0.1
+FROM jboss/keycloak:16.1.0
 
 COPY ./keycloak-bcrypt-1.5.0.jar /opt/jboss/keycloak/standalone/deployments/


### PR DESCRIPTION
<!-- Markdown help? See https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet -->
[KEYCL-130](https://myupdox.atlassian.net/browse/KEYCL-130)

<!-- Pull Request Recommendations https://myupdox.atlassian.net/wiki/spaces/EN/pages/85164043/Pull+Requests+PRs -->

### Details
Cherry picks some newer commits from the parent repo up to their upgrade to 16. We don't want to just pull in all the newest commits as they have upgraded beyond 16.1.0 already. 
